### PR TITLE
Revert "ElastiCacheクラスタのredisの場合のOutputを修正しました。"

### DIFF
--- a/template/output-elasticache.rb
+++ b/template/output-elasticache.rb
@@ -13,10 +13,10 @@ if replication
              export: _export_string(args, "cache replication group")
 
     _output "#{args[:name]} cache replication group configuration address",
-            ref_value: [ "#{args[:name]} cache replication group", "RedisEndpoint.Address" ],
+            ref_value: [ "#{args[:name]} cache replication group", "ConfigurationEndPoint.Address" ],
             export: _export_string(args, "cache replication group configuration end point address")
     _output "#{args[:name]} cache replication group configuration port",
-            ref_value: [ "#{args[:name]} cache replication group", "RedisEndpoint.Port" ],
+            ref_value: [ "#{args[:name]} cache replication group", "ConfigurationEndPoint.Port" ],
             export: _export_string(args, "cache replication group configuration end point port")
 
     _output "#{args[:name]} cache replication group primary address",


### PR DESCRIPTION
元の実装が正しかったので更新しました。

https://docs.aws.amazon.com/ja_jp/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html