### PR TITLE
Lambdaのランタイムのバリデーションルールを変更

### DIFF
--- a/template/lambda-function.rb
+++ b/template/lambda-function.rb
@@ -12,7 +12,7 @@ description = args[:description] || ""
 environment = _lambda_function_environment(args)
 function_name = args[:function_name] || ""
 runtime = _valid_values(args[:runtime],
-                        %w( nodejs nodejs4.3 java8 python2.7 ), "nodejs")
+                        %w( nodejs nodejs8.10 java8 python2.7 ), "nodejs")
 handler =
   if args.key? :handler
     args[:handler]


### PR DESCRIPTION
nodejs4.3 -> nodejs8.10
Node.jsのバージョンアップのため