### PR TITLE
Resourceと同名の論理IDでOutputを作っているoutput-*について、それに相当するOutputを別論理IDで作成するようにした(

### DIFF
--- a/template/output-alb.rb
+++ b/template/output-alb.rb
@@ -6,6 +6,9 @@ require 'kumogata/template/helper'
 _output "#{args[:name]} load balancer",
         ref_value: "#{args[:name]} load balancer",
         export: _export_string(args, "load balancer")
+_output "#{args[:name]} load balancer physical id",
+        ref_value: "#{args[:name]} load balancer",
+        export: _export_string(args, "load balancer")
 _output "#{args[:name]} load balancer dns name",
         ref_value: [ "#{args[:name]} load balancer", "DNSName" ],
         export: _export_string(args, "load balancer dns name")

--- a/template/output-autoscaling.rb
+++ b/template/output-autoscaling.rb
@@ -6,6 +6,9 @@ require 'kumogata/template/helper'
 _output "#{args[:name]} autoscaling group",
         ref_value: "#{args[:name]} autoscaling group",
         export: _export_string(args, "autoscaling group")
+_output "#{args[:name]} autoscaling group physical id",
+        ref_value: "#{args[:name]} autoscaling group",
+        export: _export_string(args, "autoscaling group")
 _output "#{args[:name]} autoscaling launch configuration",
         ref_value: "#{args[:name]} autoscaling launch configuration",
         export: _export_string(args, "autoscaling launch configuration")

--- a/template/output-dynamodb.rb
+++ b/template/output-dynamodb.rb
@@ -6,6 +6,9 @@ require 'kumogata/template/helper'
 _output "#{args[:name]} table",
         ref_value: "#{args[:name]} table",
         export: _export_string(args, "table")
+_output "#{args[:name]} table physical id",
+        ref_value: "#{args[:name]} table",
+        export: _export_string(args, "table")
 _output "#{args[:name]} table",
         ref_value: [ "#{args[:name]} table", "StreamArn" ],
         export: _export_string(args, "stream arn") if args.key? :stream

--- a/template/output-ec2.rb
+++ b/template/output-ec2.rb
@@ -8,6 +8,9 @@ public_ip = args[:public_ip] || false
 _output "#{args[:name]} instance",
         ref_value: "#{args[:name]} instance",
         export: _export_string(args, "instance")
+_output "#{args[:name]} instance physical id",
+        ref_value: "#{args[:name]} instance",
+        export: _export_string(args, "instance")
 _output "#{args[:name]} instance az",
         ref_value: [ "#{args[:name]} instance", "AvailabilityZone" ],
         export: _export_string(args, "instance az")

--- a/template/output-elasticache.rb
+++ b/template/output-elasticache.rb
@@ -11,7 +11,9 @@ if replication
     _output "#{args[:name]} cache replication group",
              ref_value: "#{args[:name]} cache replication group",
              export: _export_string(args, "cache replication group")
-
+    _output "#{args[:name]} cache replication group physical id",
+            ref_value: "#{args[:name]} cache replication group",
+            export: _export_string(args, "cache replication group")
     _output "#{args[:name]} cache replication group primary address",
             ref_value: [ "#{args[:name]} cache replication group", "PrimaryEndPoint.Address" ],
             export: _export_string(args, "cache replication group primary end point address")

--- a/template/output-elb.rb
+++ b/template/output-elb.rb
@@ -6,6 +6,9 @@ require 'kumogata/template/helper'
 _output "#{args[:name]} load balancer",
         ref_value: "#{args[:name]} load balancer",
         export: _export_string(args, "load balancer")
+_output "#{args[:name]} load balancer physical id",
+        ref_value: "#{args[:name]} load balancer",
+        export: _export_string(args, "load balancer")
 _output "#{args[:name]} load balancer canonical hosted zone name",
         ref_value: [ "#{args[:name]} load balancer", "CanonicalHostedZoneName" ],
         export: _export_string(args, "load balancer canonical hosted zone name") if args.key? :route53

--- a/template/output-emr.rb
+++ b/template/output-emr.rb
@@ -6,6 +6,9 @@ require 'kumogata/template/helper'
 _output "#{args[:name]} emr cluster",
         ref_value: "#{args[:name]} emr cluster",
         export: _export_string(args, "erm cluster")
+_output "#{args[:name]} emr cluster physical id",
+        ref_value: "#{args[:name]} emr cluster",
+        export: _export_string(args, "erm cluster")
 _output "#{args[:name]} emr cluster master public dns",
         ref_value: [ "#{args[:name]} emr cluster", "MasterPublicDNS" ],
         export: _export_string(args, "erm cluster master public dns")

--- a/template/output-instance-profile.rb
+++ b/template/output-instance-profile.rb
@@ -6,6 +6,9 @@ require 'kumogata/template/helper'
 _output "#{args[:name]} instance profile",
         ref_value: "#{args[:name]} instance profile",
         export: _export_string(args, "instance profile")
+_output "#{args[:name]} instance profile physical id",
+        ref_value: "#{args[:name]} instance profile",
+        export: _export_string(args, "instance profile")
 _output "#{args[:name]} instance profile arn",
         ref_value: [ "#{args[:name]} instance profile", "Arn" ],
         export: _export_string(args, "profile arn")

--- a/template/output-network-interface.rb
+++ b/template/output-network-interface.rb
@@ -6,6 +6,9 @@ require 'kumogata/template/helper'
 _output "#{args[:name]} network interface",
         ref_value: "#{args[:name]} network interface",
         export: _export_string(args, "network interface")
+_output "#{args[:name]} network interface physical id",
+        ref_value: "#{args[:name]} network interface",
+        export: _export_string(args, "network interface")
 _output "#{args[:name]} network interface private ip",
         ref_value: [ "#{args[:name]} network interface", "PrimaryPrivateIpAddress" ],
         export: _export_string(args, "network interface private ip")

--- a/template/output-rds.rb
+++ b/template/output-rds.rb
@@ -6,6 +6,9 @@ require 'kumogata/template/helper'
 _output "#{args[:name]} db instance",
         ref_value: "#{args[:name]} db instance",
         export: _export_string(args, "db instance")
+_output "#{args[:name]} db instance physical id",
+        ref_value: "#{args[:name]} db instance",
+        export: _export_string(args, "db instance")
 _output "#{args[:name]} db instance address",
         ref_value: [ "#{args[:name]} db instance", "Endpoint.Address" ],
         export: _export_string(args, "db instance endpoint address")

--- a/template/output-redshift.rb
+++ b/template/output-redshift.rb
@@ -6,6 +6,9 @@ require 'kumogata/template/helper'
 _output "#{args[:name]} redshift cluster",
         ref_value: "#{args[:name]} redshift cluster",
         export: _export_string(args, "redshift cluster")
+_output "#{args[:name]} redshift cluster physical id",
+        ref_value: "#{args[:name]} redshift cluster",
+        export: _export_string(args, "redshift cluster")
 _output "#{args[:name]} redshift cluster address",
         ref_value: [ "#{args[:name]} redshift cluster", "Endpoint.Address" ],
         export: _export_string(args, "redshift cluster endpoint address")

--- a/template/output-role.rb
+++ b/template/output-role.rb
@@ -6,6 +6,9 @@ require 'kumogata/template/helper'
 _output "#{args[:name]} role",
         ref_value: "#{args[:name]} role",
         export: _export_string(args, "role")
+_output "#{args[:name]} role physical id",
+        ref_value: "#{args[:name]} role",
+        export: _export_string(args, "role physical id")
 _output "#{args[:name]} role arn",
         ref_value: [ "#{args[:name]} role", "Arn" ],
         export: _export_string(args, "role arn")

--- a/template/output-role.rb
+++ b/template/output-role.rb
@@ -2,13 +2,6 @@
 # Output role
 #
 require 'kumogata/template/helper'
-
-_output "#{args[:name]} role",
-        ref_value: "#{args[:name]} role",
-        export: _export_string(args, "role")
-_output "#{args[:name]} role physical id",
-        ref_value: "#{args[:name]} role",
-        export: _export_string(args, "role physical id")
 _output "#{args[:name]} role arn",
         ref_value: [ "#{args[:name]} role", "Arn" ],
         export: _export_string(args, "role arn")

--- a/template/output-security-group.rb
+++ b/template/output-security-group.rb
@@ -6,3 +6,6 @@ require 'kumogata/template/helper'
 _output "#{args[:name]} security group",
         ref_value: "#{args[:name]} security group",
         export: _export_string(args, "security group")
+_output "#{args[:name]} security group physical id",
+        ref_value: "#{args[:name]} security group",
+        export: _export_string(args, "security group")

--- a/template/output-sqs.rb
+++ b/template/output-sqs.rb
@@ -6,3 +6,6 @@ require 'kumogata/template/helper'
 _output "#{args[:name]} queue",
         ref_value: "#{args[:name]} queue",
         export: _export_string(args, "queue")
+_output "#{args[:name]} queue physical id",
+        ref_value: "#{args[:name]} queue",
+        export: _export_string(args, "queue")

--- a/template/output-subnet.rb
+++ b/template/output-subnet.rb
@@ -6,6 +6,9 @@ require 'kumogata/template/helper'
 _output "#{args[:name]} subnet",
         ref_value: "#{args[:name]} subnet",
         export: _export_string(args, "subnet")
+_output "#{args[:name]} subnet physical id",
+        ref_value: "#{args[:name]} subnet",
+        export: _export_string(args, "subnet")
 _output "#{args[:name]} subnet az",
         ref_value: [ "#{args[:name]} subnet", "AvailabilityZone" ],
         export: _export_string(args, "subnet az")

--- a/template/output-topic.rb
+++ b/template/output-topic.rb
@@ -6,6 +6,9 @@ require 'kumogata/template/helper'
 _output "#{args[:name]} topic",
         ref_value: "#{args[:name]} topic",
         export: _export_string(args, "topic")
+_output "#{args[:name]} topic physical id",
+        ref_value: "#{args[:name]} topic",
+        export: _export_string(args, "topic")
 _output "#{args[:name]} topic name",
         ref_value: [ "#{args[:name]} topic", "TopicName" ],
         export: _export_string(args, "topic name")

--- a/template/output-vpc.rb
+++ b/template/output-vpc.rb
@@ -8,6 +8,9 @@ vpc = "#{args[:name]} vpc"
 _output "#{args[:name]} vpc",
         ref_value: vpc,
         export: _export_string(args, "vpc")
+_output "#{args[:name]} vpc physical id",
+        ref_value: vpc,
+        export: _export_string(args, "vpc")
 _output "#{args[:name]} vpc cidr block",
         ref_value: [ vpc, "CidrBlock" ],
         export: _export_string(args, "vpc cidr block")


### PR DESCRIPTION
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
- 論理IDは「テンプレート内でユニーク」である必要がある

## 編集した箇所
- `ref_value` に与えている値が、`_outputs` の引数と同値になっている箇所

※roleの物理IDに関してはそもそもoutputしないことにした(口頭説明)

## 今後の予定
- 同名の論理IDでOutputを作らないようにする