### PR TITLE
Update Amazon S3 Bucket NotificationFilter

### DIFF
--- a/lib/kumogata/template/s3.rb
+++ b/lib/kumogata/template/s3.rb
@@ -161,7 +161,20 @@ def _s3_notification_configuration(args, key)
   values.each do |value|
     array << _{
       Event value[:event]
-      Filter _{ S3Key value[:filter] } if value.key? :filter
+      Filter _{
+        S3Key _{
+          Rules value[:filters].collect{|v|
+            filter = []
+            v.each_pair do |kk, vv|
+              filter << _{
+                Name kk
+                Value vv
+              }
+            end
+            filter
+          }.flatten
+        }
+      } if value.key? :filters
       case key
       when :lambda
         Function value[:function]

--- a/test/s3_test.rb
+++ b/test/s3_test.rb
@@ -90,9 +90,9 @@ Test _s3_logging({ logging: { destination: "test", prefix: "test" } })
 
   def test_s3_notification
     template = <<-EOS
-Test _s3_notification(notification: { lambda: [ { event: "test", filter: "test", function: "test" }],
-                                      queue: [ { event: "test", filter: "test", queue: "test" }],
-                                      topic: [ { event: "test", filter: "test", topic: "test" }], })
+Test _s3_notification(notification: { lambda: [ { event: "test", filters: [ { name: "test"} ], function: "test" }],
+                                      queue: [ { event: "test", filters: [ { name: "test"} ], queue: "test" }],
+                                      topic: [ { event: "test", filters: [ { name: "test"} ], topic: "test" }], })
     EOS
     act_template = run_client_as_json(template)
     exp_template = <<-EOS
@@ -102,7 +102,14 @@ Test _s3_notification(notification: { lambda: [ { event: "test", filter: "test",
       {
         "Event": "test",
         "Filter": {
-          "S3Key": "test"
+          "S3Key": {
+            "Rules": [
+              {
+                "Name": "name",
+                "Value": "test"
+              }
+            ]
+          }
         },
         "Function": "test"
       }
@@ -111,7 +118,14 @@ Test _s3_notification(notification: { lambda: [ { event: "test", filter: "test",
       {
         "Event": "test",
         "Filter": {
-          "S3Key": "test"
+          "S3Key": {
+            "Rules": [
+              {
+                "Name": "name",
+                "Value": "test"
+              }
+            ]
+          }
         },
         "Queue": "test"
       }
@@ -120,7 +134,14 @@ Test _s3_notification(notification: { lambda: [ { event: "test", filter: "test",
       {
         "Event": "test",
         "Filter": {
-          "S3Key": "test"
+          "S3Key": {
+            "Rules": [
+              {
+                "Name": "name",
+                "Value": "test"
+              }
+            ]
+          }
         },
         "Topic": "test"
       }

--- a/test/template/s3-bucket_test.rb
+++ b/test/template/s3-bucket_test.rb
@@ -63,7 +63,7 @@ _s3_bucket "test"
 
   def test_aws_website
     template = <<-EOS
-_s3_bucket "test", bucket: "PublicBucket", website: { error: "error.html", index: "index.html", routing: [ routing: { http: "404", key_prefix: "out1/" }, redirect: { host: "ec2-11-22-333-44.compute-1.amazonaws.com", replace_key_prefix: "report-404/" } ] }
+_s3_bucket "test", bucket: "PublicBucket", notification: { lambda: [ { event: 's3:ObjectCreated:Put', filters: [ prefix: 'prod' ], function: "arn:aws:lambda:function:test" } ] }, website: { error: "error.html", index: "index.html", routing: [ routing: { http: "404", key_prefix: "out1/" }, redirect: { host: "ec2-11-22-333-44.compute-1.amazonaws.com", replace_key_prefix: "report-404/" } ] }
     EOS
     act_template = run_client_as_json(template)
     exp_template = <<-EOS
@@ -73,6 +73,24 @@ _s3_bucket "test", bucket: "PublicBucket", website: { error: "error.html", index
     "Properties": {
       "AccessControl": "PublicRead",
       "BucketName": "PublicBucket",
+      "NotificationConfiguration": {
+        "LambdaConfigurations": [
+          {
+            "Event": "s3:ObjectCreated:Put",
+            "Filter": {
+              "S3Key": {
+                "Rules": [
+                  {
+                    "Name": "prefix",
+                    "Value": "prod"
+                  }
+                ]
+              }
+            },
+            "Function": "arn:aws:lambda:function:test"
+          }
+        ]
+      },
       "Tags": [
         {
           "Key": "Name",


### PR DESCRIPTION
Amazon S3 Bucket NotificationFilter を指定して、同じバケットにファイルを作成したときに本番用の AWS Lambda 関数を実行したり、開発用の AWS Lambda 関数を実行したりしたい。

https://docs.aws.amazon.com/ja_jp/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfiguration-config-filter.html

参考: https://github.com/n0ts/kumogata-template/commit/8819b955242c55377338bf57bec24709dd1bd891