### PR TITLE
output-autoscaling において、Resourceと同名の論理IDを生成しないようにした

### DIFF
--- a/template/output-autoscaling.rb
+++ b/template/output-autoscaling.rb
@@ -6,6 +6,6 @@ require 'kumogata/template/helper'
 _output "#{args[:name]} autoscaling group physical id",
         ref_value: "#{args[:name]} autoscaling group",
         export: _export_string(args, "autoscaling group")
-_output "#{args[:name]} autoscaling launch configuration",
+_output "#{args[:name]} autoscaling launch configuration physical id",
         ref_value: "#{args[:name]} autoscaling launch configuration",
         export: _export_string(args, "autoscaling launch configuration")

--- a/test/template/output-autoscaling_test.rb
+++ b/test/template/output-autoscaling_test.rb
@@ -14,8 +14,8 @@ _output_autoscaling "test"
       "Ref": "TestAutoscalingGroup"
     }
   },
-  "TestAutoscalingLaunchConfiguration": {
-    "Description": "description of TestAutoscalingLaunchConfiguration",
+  "TestAutoscalingLaunchConfigurationPhysicalId": {
+    "Description": "description of TestAutoscalingLaunchConfigurationPhysicalId",
     "Value": {
       "Ref": "TestAutoscalingLaunchConfiguration"
     }


### PR DESCRIPTION
- #18, #20 の修正漏れ